### PR TITLE
I've made some changes to fix the Gemini request structure:

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -76,7 +76,7 @@ const fn default_cache_max_size() -> usize {
     1000 // Max 1000 entries
 }
 fn default_target_url() -> String {
-    "https://generativelanguage.googleapis.com/v1beta/openai".to_string()
+    "https://generativelanguage.googleapis.com/v1beta".to_string()
 }
 
 // --- Helper Functions ---


### PR DESCRIPTION
- I've corrected the default `target_url` in `src/config.rs` to remove the `/openai` suffix.
- I've modified `build_translated_gemini_url` in `src/handler.rs` to correctly join the base URL and the request path.
- I've fixed a failing test that was not correctly checking for the last error response.